### PR TITLE
Added commands that will update sources.list

### DIFF
--- a/src/Vagrantfile
+++ b/src/Vagrantfile
@@ -94,6 +94,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # end
 
   $script = %Q{
+    sudo cp /etc/apt/sources.list /etc/apt/sources.list.backup
+    sudo sed -i 's#http://security#http://old-releases#g' /etc/apt/sources.list
+    sudo sed -i 's#http://us.archive#http://old-releases#g' /etc/apt/sources.list
     sudo apt-get update
     sudo apt-get install nasm make build-essential grub qemu zip -y
   }


### PR DESCRIPTION
As Lucid is old release of Ubuntu and the repositories for older releases that are not supported get moved to an archive server. These repositories are available at http://old-releases.ubuntu.com. I have added some commands that will take backup of `/etc/apt/sources.list` file and will change the file such that updates will be fetched from http://old-releases.ubuntu.com server.
